### PR TITLE
Update test matrix and compatibility table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,16 @@ branches:
 bundler_args: "--without development --with ci"
 
 rvm:
-  - 2.3
   - 2.4
-  - jruby-9.1.13.0
-  - jruby-9.2.0.0
+  - 2.5
+  - 2.6
   - ruby-head
-  - jruby-head
+  - jruby-9.2.7.0
 
 matrix:
   include:
-    - rvm: 2.5
+    - rvm: 2.6
       after_script: "bundle exec codeclimate-test-reporter"
 
   allow_failures:
-    - rvm: jruby-head
     - rvm: ruby-head

--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ So you’re interested in contributing to Freedom? Check out our [contributing g
 
 This library aims to support and is [tested against][travis] the following Ruby versions:
 
-* Ruby 2.3
 * Ruby 2.4
 * Ruby 2.5
-* JRuby 9.1
+* Ruby 2.6
 * JRuby 9.2
 
 If something doesn't work on one of these versions, it's a bug.

--- a/lib/freedom/errors.rb
+++ b/lib/freedom/errors.rb
@@ -19,6 +19,11 @@ module Freedom
       self.owner = owner
     end
 
+    # @private
+    def inspect
+      "#<#{self.class.name}: #{message}>"
+    end
+
     # The descriptive message for the exception
     #
     # @api private

--- a/spec/patch_spec.rb
+++ b/spec/patch_spec.rb
@@ -93,7 +93,10 @@ RSpec.describe Freedom::Patch do
         end
 
         expect { klass.extend ConflictOnSelfFooAndSelfBar }.to(
-          raise_error(Freedom::IncompatiblePatch, /(?:foo).*(?:bar)/)
+          raise_error(Freedom::IncompatiblePatch)
+            .with_message(
+              "#{klass.inspect} already defines `foo', `bar', also defined on ConflictOnSelfFooAndSelfBar"
+            )
         )
       end
     end

--- a/spec/patch_spec.rb
+++ b/spec/patch_spec.rb
@@ -44,7 +44,13 @@ RSpec.describe Freedom::Patch do
         end
 
         expect { klass.include ConflictOnFooAndBar }.to(
-          raise_error(Freedom::IncompatiblePatch, /(?:foo).*(?:bar)/)
+          raise_error(Freedom::IncompatiblePatch)
+            .with_message(
+              Regexp.new(
+                "#{klass.inspect} already defines (?:`bar', `foo'|`foo', `bar'), " \
+                'also defined on ConflictOnFooAndBar'
+              )
+            )
         )
       end
     end
@@ -95,7 +101,10 @@ RSpec.describe Freedom::Patch do
         expect { klass.extend ConflictOnSelfFooAndSelfBar }.to(
           raise_error(Freedom::IncompatiblePatch)
             .with_message(
-              "#{klass.inspect} already defines `foo', `bar', also defined on ConflictOnSelfFooAndSelfBar"
+              Regexp.new(
+                "#{klass.inspect} already defines (?:`bar', `foo'|`foo', `bar'), " \
+                'also defined on ConflictOnSelfFooAndSelfBar'
+              )
             )
         )
       end


### PR DESCRIPTION
JRuby has different compatibilities with different versions of the JDK.
Since 9.2 has been out for over a year, let's drop support for 9.1.