### PR TITLE
Reorganize CI tasks and dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,14 @@ AllCops:
     - "Guardfile"
     - "Rakefile"
     - "*.gemspec"
+    - "spec/**.rb"
   Exclude:
     - "tmp/**/*"
   TargetRubyVersion: 2.3
+
+Layout/EmptyLineBetweenDefs:
+  Exclude:
+    - "spec/patch_spec.rb"
 
 Metrics/AbcSize:
   Description: A calculated magnitude based on number of assignments, branches, and
@@ -33,3 +38,14 @@ Metrics/MethodLength:
   Exclude:
     - "Rakefile"
     - "spec/**/*_spec.rb"
+
+Style/LambdaCall:
+  EnforcedStyle: braces
+
+Style/Semicolon:
+  Exclude:
+    - "spec/patch_spec.rb"
+
+Style/SingleLineMethods:
+  Exclude:
+    - "spec/patch_spec.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,23 @@ branches:
   - master
   - /^v\d+\.\d+(?:\.\d+)?(?:-\S*)?$/
 
-bundler_args: "--without development --with ci"
+bundler_args: "--jobs 4 --retry 3 --without development"
 
 rvm:
   - 2.4
   - 2.5
-  - 2.6
   - ruby-head
   - jruby-9.2.7.0
 
 matrix:
   include:
     - rvm: 2.6
-      after_script: "bundle exec codeclimate-test-reporter"
+      before_script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
+      after_script:
+        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
   allow_failures:
     - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -14,22 +14,15 @@ group :development do
   gem 'guard-rubocop'
   gem 'guard-yard'
   gem 'inch'
+  gem 'pry'
   gem 'rubocop', '0.58.2'
   gem 'yard', '~> 0.9'
-  gem 'yard-doctest'
   gem 'yardstick'
 
   group :test do
-    gem 'pry'
     gem 'rake'
+    gem 'rspec', '~> 3.6'
+    gem 'simplecov', require: false
+    gem 'yard-doctest'
   end
-end
-
-group :ci do
-  gem 'codeclimate-test-reporter', require: false
-  gem 'simplecov', require: false
-end
-
-group :test do
-  gem 'rspec', '~> 3.6'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,6 @@ GEM
   specs:
     ast (2.4.0)
     benchmark-ips (2.7.2)
-    codeclimate-test-reporter (1.0.8)
-      simplecov (<= 0.13)
     coderay (1.1.2)
     diff-lcs (1.3)
     docile (1.1.5)
@@ -120,7 +118,6 @@ PLATFORMS
 DEPENDENCIES
   benchmark-ips
   bundler (~> 1.16)
-  codeclimate-test-reporter
   freedom!
   guard-bundler
   guard-inch

--- a/lib/freedom/errors.rb
+++ b/lib/freedom/errors.rb
@@ -19,7 +19,12 @@ module Freedom
       self.owner = owner
     end
 
+    # Formats the error for debugging purposes
+    #
+    # @api private
     # @private
+    #
+    # @return [String]
     def inspect
       "#<#{self.class.name}: #{message}>"
     end

--- a/lib/freedom/patch.rb
+++ b/lib/freedom/patch.rb
@@ -11,43 +11,42 @@ module Freedom
   # Note that you currently cannot define a freedom patch that defines both
   # instance and class methods. `Module.include` and `Method.extend` do not
   # naturally allow you to handle both.
-  #
-  # @api public
-  #
-  # @example Creates a patch that adds the `#quack` method.
-  #   module Quacking
-  #     extend Freedom::Patch.(:instance_method)
-  #
-  #     def quack
-  #       'quack'
-  #     end
-  #   end
-  #
-  #   class Duck
-  #     include Quacking
-  #   end
-  #
-  #   duck = Duck.new
-  #   duck.quack  #=> 'quack'
-  #
-  # @example Creates a patch that adds class introspection.
-  #   module ClassIntrospection
-  #     extend Freedom::Patch.(:class_method)
-  #
-  #     def methods_with_owners
-  #       methods
-  #         .group_by { |method_name| method(method_name).owner }
-  #     end
-  #   end
-  #
-  #   Integer.extend ClassIntrospection
-  #   Integer.methods_with_owners
   module Patch
-    # Builds a freedom patch for the given method type. This patch can safely
-    # monkey-patch a module or class and ensure that none of the methods
-    # conflict with methods already defined on the base.
+    # Builds a freedom patch for the given method type
+    #
+    # This patch can safely monkey-patch a module or class and ensure that none
+    # of the methods conflict with methods already defined on the base.
     #
     # @api public
+    #
+    # @example Creates a patch that adds the `#quack` method.
+    #   module Quacking
+    #     extend Freedom::Patch.(:instance_method)
+    #
+    #     def quack
+    #       'quack'
+    #     end
+    #   end
+    #
+    #   class Duck
+    #     include Quacking
+    #   end
+    #
+    #   duck = Duck.new
+    #   duck.quack  #=> 'quack'
+    #
+    # @example Creates a patch that adds class introspection.
+    #   module ClassIntrospection
+    #     extend Freedom::Patch.(:class_method)
+    #
+    #     def methods_with_owners
+    #       methods
+    #         .group_by { |method_name| method(method_name).owner }
+    #     end
+    #   end
+    #
+    #   Integer.extend ClassIntrospection
+    #   Integer.methods_with_owners
     #
     # @param method_type [Symbol] the type of methods to check against the
     #   freedom patch, one of :instance_method or :class_method

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Freedom::IncompatiblePatch do
+  describe '#inspect' do
+    it 'renders a readable representation of the error' do
+      MyModule = Module.new
+
+      error = described_class.new(Integer, %w[foo], MyModule)
+
+      expect(error.inspect).to(
+        eq(
+          '#<Freedom::IncompatiblePatch: Integer already defines ' \
+          "`foo', also defined on MyModule>"
+        )
+      )
+    end
+  end
+end

--- a/spec/freedom_spec.rb
+++ b/spec/freedom_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Freedom do
   it 'has a version number' do
     expect(Freedom::VERSION).not_to be nil


### PR DESCRIPTION
In order to speed up CI, this limits the dependencies that are installed
and toggles the tasks that are run to be exactly what we want to run in
CI, yet still allow the default workflow to run all of the tasks that we
want.

As part of this, we now use the CodeClimate test reporter rather than
the deprecated gem.